### PR TITLE
Add lm_eval configs for HPU

### DIFF
--- a/recipes/configs/llama3_1/8B_lora_single_device_hpu.yaml
+++ b/recipes/configs/llama3_1/8B_lora_single_device_hpu.yaml
@@ -55,7 +55,7 @@ dataset:
   packed: True  # True increases speed
 seed: null
 shuffle: True
-batch_size: 2
+batch_size: 1
 
 # Optimizer and Scheduler
 optimizer:

--- a/recipes/configs/llama3_1/eval_configs_hpu/custom_eval_base.yaml
+++ b/recipes/configs/llama3_1/eval_configs_hpu/custom_eval_base.yaml
@@ -1,0 +1,37 @@
+# Model Arguments
+model:
+  _component_: torchtune.models.llama3_1.llama3_1_8b
+
+checkpointer:
+  _component_: torchtune.training.FullModelHFCheckpointer
+  checkpoint_dir: /tmp/Meta-Llama-3.1-8B-Instruct/
+  checkpoint_files: [
+    model-00001-of-00004.safetensors,
+    model-00002-of-00004.safetensors,
+    model-00003-of-00004.safetensors,
+    model-00004-of-00004.safetensors
+  ]
+  recipe_checkpoint: null
+  output_dir: /tmp/torchtune/llama3_1_8B/full_single_device
+  model_type: LLAMA3
+
+# Tokenizer
+tokenizer:
+  _component_: torchtune.models.llama3.llama3_tokenizer
+  path: /tmp/Meta-Llama-3.1-8B-Instruct/original/tokenizer.model
+  max_seq_len: 512
+
+# Environment
+device: hpu
+dtype: bf16
+seed: 1234 # It is not recommended to change this seed, b/c it matches EleutherAI's default seed
+compile: True
+# EleutherAI specific eval args
+tasks: ["hellaswag"]
+limit: null
+max_seq_length: 512
+batch_size: 32
+enable_kv_cache: True
+
+# Quantization specific args
+quantizer: null

--- a/recipes/configs/llama3_1/eval_configs_hpu/custom_eval_full_ft.yaml
+++ b/recipes/configs/llama3_1/eval_configs_hpu/custom_eval_full_ft.yaml
@@ -1,0 +1,37 @@
+# Model Arguments
+model:
+  _component_: torchtune.models.llama3_1.llama3_1_8b
+
+checkpointer:
+  _component_: torchtune.training.FullModelHFCheckpointer
+  checkpoint_dir: /tmp/torchtune/llama3_1_8B/full_single_device/base_model/
+  checkpoint_files: [
+     /tmp/torchtune/llama3_1_8B/full_single_device/epoch_0/ft-model-00001-of-00004.safetensors,
+     /tmp/torchtune/llama3_1_8B/full_single_device/epoch_0/ft-model-00002-of-00004.safetensors,
+     /tmp/torchtune/llama3_1_8B/full_single_device/epoch_0/ft-model-00003-of-00004.safetensors,
+     /tmp/torchtune/llama3_1_8B/full_single_device/epoch_0/ft-model-00004-of-00004.safetensors,
+  ]
+  recipe_checkpoint: null
+  output_dir: /tmp/torchtune/llama3_1_8B/full_single_device
+  model_type: LLAMA3
+
+# Tokenizer
+tokenizer:
+  _component_: torchtune.models.llama3.llama3_tokenizer
+  path: /tmp/Meta-Llama-3.1-8B-Instruct/original/tokenizer.model
+  max_seq_len: 512
+
+# Environment
+device: hpu
+dtype: bf16
+seed: 1234 # It is not recommended to change this seed, b/c it matches EleutherAI's default seed
+compile: True
+# EleutherAI specific eval args
+tasks: ["hellaswag"]
+limit: null
+max_seq_length: 512
+batch_size: 32
+enable_kv_cache: True
+
+# Quantization specific args
+quantizer: null

--- a/recipes/configs/llama3_1/eval_configs_hpu/custom_eval_lora_ft.yaml
+++ b/recipes/configs/llama3_1/eval_configs_hpu/custom_eval_lora_ft.yaml
@@ -1,0 +1,38 @@
+# Model Arguments
+model:
+  _component_: torchtune.models.llama3_1.llama3_1_8b
+
+Full finetuned
+checkpointer:
+  _component_: torchtune.training.FullModelHFCheckpointer
+  checkpoint_dir: /tmp/Meta-Llama-3.1-8B-Instruct/
+  checkpoint_files: [
+     /tmp/torchtune/llama3_1_8B/lora_single_device/epoch_0/ft-model-00001-of-00004.safetensors,
+     /tmp/torchtune/llama3_1_8B/lora_single_device/epoch_0/ft-model-00002-of-00004.safetensors,
+     /tmp/torchtune/llama3_1_8B/lora_single_device/epoch_0/ft-model-00003-of-00004.safetensors,
+     /tmp/torchtune/llama3_1_8B/lora_single_device/epoch_0/ft-model-00004-of-00004.safetensors,
+  ]
+  recipe_checkpoint: null
+  output_dir: output
+  model_type: LLAMA3
+
+# Tokenizer
+tokenizer:
+  _component_: torchtune.models.llama3.llama3_tokenizer
+  path: /tmp/Meta-Llama-3.1-8B-Instruct/original/tokenizer.model
+  max_seq_len: 512
+
+# Environment
+device: hpu
+dtype: bf16
+seed: 1234 # It is not recommended to change this seed, b/c it matches EleutherAI's default seed
+compile: True
+# EleutherAI specific eval args
+tasks: ["hellaswag"]
+limit: null
+max_seq_length: 512
+batch_size: 32
+enable_kv_cache: True
+
+# Quantization specific args
+quantizer: null


### PR DESCRIPTION
This PR adds configs to run lm_eval in HPU.

Configs are generated using the steps mentioned in https://pytorch.org/torchtune/main/tutorials/llama3.html#evaluating-fine-tuned-llama3-8b-models-with-eleutherai-s-eval-harness and are modified to support HPU device.

To launch, run the following command :
`PT_HPU_LAZY_MODE=0 TORCH_COMPILE_BACKEND=hpu_backend tune run eleuther_eval --config <config_file_name>`